### PR TITLE
fix: use bridgetown url in production

### DIFF
--- a/plugins/builders/vercel_url.rb
+++ b/plugins/builders/vercel_url.rb
@@ -1,7 +1,7 @@
 class VercelUrl < SiteBuilder
   def build
     hook :site, :pre_render do |s|
-      next unless ENV["VERCEL_URL"]
+      next unless ENV["VERCEL_URL"] && ENV["VERCEL_ENV"] != "production"
       Bridgetown.logger.info("Subbing Vercel URL")
       site.config.update(url: "https://" + ENV["VERCEL_URL"])
     end


### PR DESCRIPTION
fixes #64