### PR TITLE
build: prevent prettier from autoformatting raindrop dumps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-src/_posts/archive/**/*.md
 output
 .bridgetown-build
 .obsidian
@@ -8,3 +7,6 @@ node_modules
 .husky
 Gemfile
 yarn.lock
+
+src/_posts/archive/**/*.md
+src/_data/raindrop/**/*.json


### PR DESCRIPTION
There are some formatting discrepancies happening and I've finally hit my limit.

This is the start but I am considering (heavily) ripping out Husky and lint-staged.