### PR TITLE
Fix link to GitHub repository

### DIFF
--- a/src/_pages/md/site_resources.md
+++ b/src/_pages/md/site_resources.md
@@ -48,6 +48,7 @@ You can contact me to ask me what data I hold about you, which is probably an em
 [9]: https://esbuild.github.io
 [10]: https://alpinejs.dev
 [11]: https://github.com/andrewmcodes/andrewm-codes-site
+[11]: https://github.com/andrewmcodes/andrewm.codes
 [12]: https://vercel.com/
 [13]: https://www.cloudflare.com
 [14]: https://plausible.io/


### PR DESCRIPTION
## PR Purpose

A link to the GitHub repo on [this page](https://andrewm.codes/site/) was broken.

## Changes Summary

This change updates the link to the point to the correct GitHub repository.

---

[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org/)
