### PR TITLE
feat(talks): add "We Are the Ruby Community" talk

### DIFF
--- a/src/_data/talks.yml
+++ b/src/_data/talks.yml
@@ -21,3 +21,14 @@
       href: https://www.bridgetownconf.rocks/#talk-bridgetown-dangerous
     - label: slides
       href: https://speakerdeck.com/andrewmcodes/learn-enough-bridgetown-to-be-dangerous
+
+- slug: we-are-the-ruby-community
+  title: "We Are the Ruby Community"
+  date: 2026-06-12
+  venue: Blastoff Rails
+  city: Albuquerque, NM
+  duration: 30 min
+  excerpt: Many developers feel like observers of the Ruby community rather than participants in it. This talk reframes what community actually means, breaks down the invisible barriers that make people feel like they don't belong, and shows practical ways anyone can participate right away. The goal is to show that the Ruby community isn't something you join, it's something you help create.
+  links:
+    - label: slides
+      href: https://speakerdeck.com/andrewmcodes/we-are-the-ruby-community


### PR DESCRIPTION
## Summary

Adds a new talk to `src/_data/talks.yml`:

- **Title:** We Are the Ruby Community
- **Event:** Blastoff Rails · Albuquerque, NM
- **Date:** 2026-06-12
- **Duration:** 30 min
- **Slides:** https://speakerdeck.com/andrewmcodes/we-are-the-ruby-community

## Notes

- Slides-only entry (no video link), so it won't emit a JSON-LD `VideoObject` — consistent with other slides-only talks.
- The current `talks.yml` schema has no field for a conference URL, so the Blastoff Rails link isn't surfaced on the card.