### PR TITLE
feat(home): homepage positioning — hero, CTAs, featured work, now

### DIFF
--- a/src/_components/featured_card.erb
+++ b/src/_components/featured_card.erb
@@ -1,0 +1,33 @@
+<%= render Link.new(
+  href: field(:href),
+  external: true,
+  class: "group flex flex-col gap-1 bg-sage-1 hover:bg-sage-2 transition-colors py-3.5 md:p-5"
+) do %>
+  <div class="flex items-center gap-2.5 mb-1">
+    <span
+      class="
+        inline-flex items-center gap-1.5 font-semibold text-[15px] tracking-tight text-sage-12
+      "
+    >
+      <%= field(:title) %>
+      <%= render Icon.new(
+        name: "arrow_top_right",
+        class: "w-3 h-3 text-sage-8 group-hover:text-mint-11 transition-colors",
+      ) %>
+    </span>
+    <% if field(:kind) %>
+      <span
+        class="
+          ml-auto font-mono text-[10px] uppercase tracking-[0.06em] rounded-full border
+          px-1.5 py-px text-sage-10 border-sage-4
+        "
+      >
+        <%= field(:kind) %>
+      </span>
+    <% end %>
+  </div>
+  <div class="text-[13.5px] leading-snug text-sage-11 my-1 mb-4 text-pretty"><%= field(:desc) %></div>
+  <% if field(:label) %>
+    <div class="mt-auto font-mono text-[11.5px] text-sage-10"><%= field(:label) %></div>
+  <% end %>
+<% end %>

--- a/src/_components/featured_card.rb
+++ b/src/_components/featured_card.rb
@@ -1,0 +1,17 @@
+# Card highlighting a featured proof point (work, open source, podcast, writing).
+#
+# Reads a plain hash from `src/_data/featured.yml` so the homepage owns the
+# content while the design system owns the treatment.
+class FeaturedCard < Bridgetown::Component
+  # @param item [Hash] a featured item from `src/_data/featured.yml`
+  def initialize(item:)
+    @item = item
+  end
+
+  # Reads a field by either string or symbol key.
+  # @param key [String, Symbol] the field name
+  # @return [Object, nil] the value, or nil if absent
+  def field(key)
+    @item[key.to_s] || @item[key.to_sym]
+  end
+end

--- a/src/_components/home_hero.erb
+++ b/src/_components/home_hero.erb
@@ -37,11 +37,19 @@
     <%= render Link.new(href: "/speaking/", variant: :inline) do %>talks and podcasts<% end %>
     here. Mostly so I can find them again later.
   </p>
-  <%= render Link.new(href: "/posts/", variant: :action) do %>
-    Read the writing
-    <%= render Icon.new(
-      name: "arrow_right",
-      class: "transition-transform group-hover:translate-x-1",
-    ) %>
-  <% end %>
+  <div class="mt-8 flex flex-wrap items-center gap-3">
+    <%= render Button.new(href: "/posts/", variant: :primary, size: :xl) do %>
+      Read the writing
+      <%= render Icon.new(
+        name: "arrow_right",
+        class: "ml-1.5 inline-block transition-transform group-hover:translate-x-0.5",
+      ) %>
+    <% end %>
+    <%= render Button.new(href: "/projects/", variant: :secondary, size: :xl) do %>
+      Browse projects
+    <% end %>
+    <%= render Button.new(href: "https://remoteruby.com/", variant: :ghost, size: :xl) do %>
+      Listen to Remote Ruby
+    <% end %>
+  </div>
 </section>

--- a/src/_components/home_hero.erb
+++ b/src/_components/home_hero.erb
@@ -21,9 +21,10 @@
       text-[16.5px] text-sage-11 max-w-[600px] leading-[1.65] m-0 mb-4 text-pretty
     "
   >
-    I write about Rails, Ruby tooling, and the stuff I learn while shipping
-    software for a living. Most posts started as a note I was writing for
-    myself and turned out to be useful for somebody else.
+    I spend my time on the parts of Rails that compound — fast CI and test
+    suites, developer tooling, and the workflow details that make a team
+    quicker. Most of what I learn shipping software for a living ends up
+    written down here.
   </p>
   <p
     class="

--- a/src/_components/home_now.erb
+++ b/src/_components/home_now.erb
@@ -1,0 +1,28 @@
+<ul class="flex flex-col gap-3.5 m-0 p-0 list-none">
+  <li class="grid grid-cols-[92px_1fr] gap-4 max-sm:grid-cols-1 max-sm:gap-0.5">
+    <span class="font-mono text-[11.5px] text-sage-10 lowercase pt-px">building</span>
+    <span class="text-[14.5px] leading-snug text-sage-11 text-pretty">
+      Shipping Ruby on Rails at
+      <%= render Link.new(href: "https://www.podia.com/", variant: :inline) do %>Podia<% end %>,
+      with a soft spot for CI, tooling, and developer experience.
+    </span>
+  </li>
+  <% if episode_url %>
+    <li class="grid grid-cols-[92px_1fr] gap-4 max-sm:grid-cols-1 max-sm:gap-0.5">
+      <span class="font-mono text-[11.5px] text-sage-10 lowercase pt-px">podcasting</span>
+      <span class="text-[14.5px] leading-snug text-sage-11 text-pretty">
+        Co-hosting
+        <%= render Link.new(href: episode_url, variant: :inline) do %>Remote Ruby<% end %><% if episode_date %>, latest episode out <%= episode_date %><% end %>.
+      </span>
+    </li>
+  <% end %>
+  <% if talk_field(:title) %>
+    <li class="grid grid-cols-[92px_1fr] gap-4 max-sm:grid-cols-1 max-sm:gap-0.5">
+      <span class="font-mono text-[11.5px] text-sage-10 lowercase pt-px">speaking</span>
+      <span class="text-[14.5px] leading-snug text-sage-11 text-pretty">
+        Most recently gave
+        <%= render Link.new(href: "/speaking/", variant: :inline) do %><%= talk_field(:title) %><% end %><% if talk_field(:venue) %> at <%= talk_field(:venue) %><% end %><% if talk_date %> (<%= talk_date %>)<% end %>.
+      </span>
+    </li>
+  <% end %>
+</ul>

--- a/src/_components/home_now.rb
+++ b/src/_components/home_now.rb
@@ -1,0 +1,44 @@
+# Compact "currently" strip of the freshest real-world signals.
+#
+# Surfaces active work (role, latest podcast episode, most recent talk) so the
+# homepage shows current momentum instead of leaning on blog post dates, which
+# can read as stale even when the work behind the scenes is active.
+class HomeNow < Bridgetown::Component
+  # @param episode [Hash, nil] latest episode data (`site.data.remote_ruby`)
+  # @param talk [Hash, nil] most recent talk from `src/_data/talks.yml`
+  def initialize(episode:, talk:)
+    @episode = episode
+    @talk = talk
+  end
+
+  # @return [String, nil] the episode listen URL
+  def episode_url
+    @episode && @episode["url"]
+  end
+
+  # @return [String, nil] the episode publish month, e.g. "Jul 2026"
+  def episode_date
+    raw = @episode && @episode["published_at"]
+    return nil unless raw
+    Date.parse(raw.to_s).strftime("%b %Y")
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  # Reads a talk field by either string or symbol key.
+  # @param key [String, Symbol] the field name
+  # @return [Object, nil] the value, or nil if absent
+  def talk_field(key)
+    return nil unless @talk
+    @talk[key.to_s] || @talk[key.to_sym]
+  end
+
+  # @return [String, nil] the talk month, e.g. "Jun 2026"
+  def talk_date
+    d = talk_field(:date)
+    return nil unless d
+    (d.is_a?(String) ? Date.parse(d) : d).strftime("%b %Y")
+  rescue ArgumentError, TypeError
+    nil
+  end
+end

--- a/src/_data/featured.yml
+++ b/src/_data/featured.yml
@@ -1,0 +1,22 @@
+# Curated proof points surfaced in the homepage "featured work" section.
+# Each item is a real thing worth pointing people to first.
+- title: Podia
+  kind: work
+  desc: Ruby on Rails engineer building the all-in-one platform creators use to sell courses, digital downloads, and community. The day job that keeps everything else grounded in real product work.
+  href: https://www.podia.com/
+  label: podia.com
+- title: Remote Ruby
+  kind: podcast
+  desc: The weekly podcast I co-host on Rails, Ruby, and whatever the community is talking about that week — 350+ episodes and counting.
+  href: https://remoteruby.com/
+  label: remoteruby.com
+- title: Rails Extension Power Pack
+  kind: open source
+  desc: A curated VS Code extension pack for Ruby on Rails development. One of my most-installed open source projects.
+  href: https://github.com/andrewmcodes/rails-extension-power-pack
+  label: github.com/andrewmcodes
+- title: Shared GitHub Actions
+  kind: open source
+  desc: Reusable GitHub Actions and CI building blocks I lean on across projects — the CI-and-tooling work I care about, out in the open.
+  href: https://github.com/andrewmcodes/actions
+  label: github.com/andrewmcodes

--- a/src/index.erb
+++ b/src/index.erb
@@ -11,7 +11,21 @@ title: andrewm.codes
 <%= render PageShell.new(spacing: :home) do %>
   <%= render HomeHero.new %>
 
-  <%= render PageSection.new(spacing: :home_first) do %>
+  <% if site.data.featured&.any? %>
+    <%= render PageSection.new(spacing: :home_first) do %>
+      <%= render SectionHead.new(
+        title: "featured work",
+        description: "A few things I'm proud of and point people to most often.",
+      ) %>
+      <%= render CardGrid.new do %>
+        <% site.data.featured.each do |item| %>
+          <%= render FeaturedCard.new(item: item) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= render PageSection.new(spacing: :home) do %>
     <%= render SectionHead.new(
       title: "recent posts",
       link_label: "all posts",

--- a/src/index.erb
+++ b/src/index.erb
@@ -11,8 +11,16 @@ title: andrewm.codes
 <%= render PageShell.new(spacing: :home) do %>
   <%= render HomeHero.new %>
 
+  <%= render PageSection.new(spacing: :home_first) do %>
+    <%= render SectionHead.new(
+      title: "now",
+      description: "What I'm actively working on right now.",
+    ) %>
+    <%= render HomeNow.new(episode: latest_episode, talk: latest_talk) %>
+  <% end %>
+
   <% if site.data.featured&.any? %>
-    <%= render PageSection.new(spacing: :home_first) do %>
+    <%= render PageSection.new(spacing: :home) do %>
       <%= render SectionHead.new(
         title: "featured work",
         description: "A few things I'm proud of and point people to most often.",


### PR DESCRIPTION
Homepage pass addressing the positioning cluster, while preserving the site's understated personal voice (no "looking for work" / hard-sell copy).

## What changed
- **Hero copy (#517)** — supporting line now leads with the specific, differentiated value: fast CI and test suites, developer tooling, and team-velocity work. Voice and identity headline unchanged.
- **Clear CTAs (#518)** — replaced the lone text link with a button group: primary **Read the writing** above the fold, plus secondary **Browse projects** and **Listen to Remote Ruby**.
- **Featured work (#519)** — new proof section above the post list, data-driven via `src/_data/featured.yml` + a `FeaturedCard` component (Podia, Remote Ruby, and flagship open source), each with a concise blurb and link.
- **Now section (#520)** — compact current-activity strip below the hero (role, latest Remote Ruby episode with date, most recent talk) built from existing site data so it stays fresh automatically. Homepage reordered so "now" and featured work lead, keeping old post dates off the first screen.

## Notes
- `#521` (author cornerstone SEO articles) was intentionally **not** automated — deferred to human authorship; closed separately.
- `#522`/`#524`/`#525` were already satisfied by existing code and closed with references.
- Site builds cleanly; full test suite passes (97 runs, 0 failures); `standardrb` and Prettier clean.
- Opened as a PR rather than pushed to `main` so the homepage changes (subjective/visual) can be reviewed on the CI preview URL before going live.

Closes #517
Closes #518
Closes #519
Closes #520