### PR TITLE
ci(perf): parallelize Lighthouse and cut runs per URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    env:
+      LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -89,10 +91,30 @@ jobs:
         with:
           name: site-output
           path: output
-      - name: Lighthouse CI
-        env:
-          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
-        run: pnpm exec lhci autorun
+      # Lighthouse dominates this job's wall-clock. Instead of collecting all
+      # seven URLs serially in one `lhci autorun`, split them into three shards
+      # that run as parallel steps so the Chrome runs overlap. Each `autorun`
+      # auto-assigns a free port and posts per-URL GitHub statuses (context
+      # `lhci/url<path>`), so shards never collide on ports or clobber each
+      # other's statuses. `--collect.url` overrides the list in lighthouserc.cjs
+      # — keep the union of these shards in sync with that file.
+      - parallel:
+          - name: Lighthouse (home, posts, about)
+            run: >-
+              pnpm exec lhci autorun
+              --collect.url=http://localhost/
+              --collect.url=http://localhost/posts/
+              --collect.url=http://localhost/about/
+          - name: Lighthouse (projects, speaking)
+            run: >-
+              pnpm exec lhci autorun
+              --collect.url=http://localhost/projects/
+              --collect.url=http://localhost/speaking/
+          - name: Lighthouse (post, tag)
+            run: >-
+              pnpm exec lhci autorun
+              --collect.url=http://localhost/p/kill-process-on-port/
+              --collect.url=http://localhost/tag/rails/
 
   deploy:
     name: deploy to cloudflare

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -4,11 +4,17 @@
 // Runs against the already-built static output (./output), so CI can reuse the
 // `site-output` artifact from the production build job rather than rebuilding.
 // Performance is a soft warning; accessibility and SEO are enforced as errors.
+//
+// `numberOfRuns: 1` — this job is informational (it does not gate the deploy)
+// and a11y/SEO scores are deterministic on static HTML, so the median-of-3
+// smoothing isn't worth 3x the Chrome runtime. CI further shards this URL list
+// across concurrent `lhci autorun` steps (see .github/workflows/ci.yml); keep
+// the two lists in sync.
 module.exports = {
   ci: {
     collect: {
       staticDistDir: "./output",
-      numberOfRuns: 3,
+      numberOfRuns: 1,
       url: [
         "http://localhost/",
         "http://localhost/posts/",


### PR DESCRIPTION
## Summary

The `lighthouse` CI job was the slow one: it ran `lhci autorun` over all seven URLs **serially** at `numberOfRuns: 3` — 21 headless Chrome runs back to back.

This PR speeds it up two ways:

- **`numberOfRuns` 3 → 1** in `lighthouserc.cjs`. The job is informational (does not gate the deploy) and a11y/SEO scores are deterministic on static HTML, so median-of-3 smoothing isn't worth 3× the Chrome runtime.
- **Shard the URLs across three concurrent parallel steps** (using the new GitHub Actions step-level `parallel` feature already used by the `checks` job) so the Chrome runs overlap instead of running one after another.

Net: wall-clock Lighthouse work drops from **21 serial runs to ~3**.

## Why sharding is safe

Verified against `@lhci/cli` 0.15.1:

- `--collect.url` **overrides** the config's `url` array (doesn't append), so each shard runs only its subset.
- Each `lhci autorun` **auto-assigns a free port** for its static server, so concurrent instances don't collide.
- `lhci upload` posts **one GitHub status per URL** with context `lhci/url<path>` derived from the URL path — so shards produce distinct, non-clobbering statuses regardless of which shard a URL lands in.

## Notes

- The URL list now lives in both `lighthouserc.cjs` (canonical/fallback) and the workflow shards; both files carry a cross-reference comment to keep them in sync.
- Behavior is unchanged for assertions (SEO/a11y errors, perf warning) — only run count and concurrency changed.