### PR TITLE
refactor: replace email links with bluesky contact links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,14 @@ Run a single test file: `bundle exec rake test TEST=test/test_homepage.rb`. Run 
 
 Lint only: `bundle exec standardrb` (CI uses this without `--fix`).
 
+## Commit conventions
+
+**Commit messages MUST follow [Conventional Commits](https://www.conventionalcommits.org/)** — CI runs `commitlint` (`commitlint.config.js` extends `@andrewmcodes` → `@commitlint/config-conventional`) and a non-conforming message fails the build. Every commit subject must be `<type>(<optional scope>): <description>`:
+
+- **Allowed types:** `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
+- Type is lowercase; description starts lowercase and has no trailing period (e.g. `refactor: point contact links to bluesky`, not `Remove email links.`).
+- Header (type + scope + description) stays under 100 chars. Body/footer line length is unrestricted (relaxed by the `@andrewmcodes` config), so wrap the body however reads best.
+
 ## Architecture
 
 ### Resource pipeline

--- a/src/_pages/about.md
+++ b/src/_pages/about.md
@@ -18,11 +18,11 @@ I grew up in North Carolina, studied Computer Science, and eventually landed in 
 
 ## Elsewhere
 
-[Bluesky](https://bsky.app/profile/andrewm.codes) · [GitHub](https://github.com/andrewmcodes) · [LinkedIn](https://www.linkedin.com/in/andrew-mason) · [Remote Ruby](https://remoteruby.com) · [Email](mailto:hello@andrewmcodes.dev)
+[Bluesky](https://bsky.app/profile/andrewm.codes) · [GitHub](https://github.com/andrewmcodes) · [LinkedIn](https://www.linkedin.com/in/andrew-mason) · [Remote Ruby](https://remoteruby.com)
 
 ## Speaking & podcasts
 
-If you'd like me at your conference, on your podcast, or generally in a room with a microphone — [email me](mailto:hello@andrewmcodes.dev). I'm slow to reply but I do reply.
+If you'd like me at your conference, on your podcast, or generally in a room with a microphone — [reach out on Bluesky](https://bsky.app/profile/andrewm.codes). I'm slow to reply but I do reply.
 
 ## Colophon
 

--- a/src/_pages/speaking.erb
+++ b/src/_pages/speaking.erb
@@ -17,7 +17,7 @@ description: Talks I've given, podcasts I host, shows I've been on, and CFPs I'v
   <%= render Ui::PageHeader.new(title: "Speaking") do %>
     Talks I've given, podcasts I host, shows I've been on, and CFPs I've
     submitted. Want me on yours?
-    <a href="mailto:hello@andrewmcodes.dev" class="text-mint-11 hover:underline">Get in touch</a>.
+    <a href="https://bsky.app/profile/andrewm.codes" class="text-mint-11 hover:underline">Get in touch on Bluesky</a>.
   <% end %>
 
   <% if active_pods.any? %>


### PR DESCRIPTION
## Summary

Removes all `mailto:hello@andrewmcodes.dev` links from the site — no more inviting anyone to email. Contact paths now point at Bluesky instead.

## Changes

- **`src/_pages/about.md`** — dropped the `Email` entry from the "Elsewhere" list; changed the "email me" CTA to "reach out on Bluesky".
- **`src/_pages/speaking.erb`** — the "Get in touch" link now points to Bluesky instead of `mailto:`.

No remaining `mailto:` or email references in `src/`.